### PR TITLE
Public print typediff

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,9 @@ New library features
   `c` to cleanly cancel immediately, `d` to detach, `i` for a profile peek,
   `v` to toggle verbose mode showing elapsed time, CPU%, and memory usage, and `?` for help. ([#60943]).
 * Instances of an `Enum` can now be given their own docstrings within the `@enum` definition ([#61955]).
+* `Base.Experimental.print_type_diff` prints a type with the parts that differ
+  from a reference type highlighted. It backs the `MethodError` "Closest
+  candidates" highlighting and can be reused in custom `showerror` methods ([#XXXXX]).
 
 Standard library changes
 ------------------------

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -457,14 +457,18 @@ stacktrace_expand_basepaths()::Bool = Base.get_bool_env("JULIA_STACKTRACE_EXPAND
 stacktrace_contract_userdir()::Bool = Base.get_bool_env("JULIA_STACKTRACE_CONTRACT_HOMEDIR", true) === true
 stacktrace_linebreaks()::Bool = Base.get_bool_env("JULIA_STACKTRACE_LINEBREAKS", false) === true
 
-# Print `::<sig>` with structural framing (type names, braces) in the default
-# color, matching parameters and their separating commas in gray, and the
-# topmost differing subtree(s) in `error_color`.
-function show_type_diff(io::IO, @nospecialize(sig), @nospecialize(called), use_color::Bool, top_level::Bool=true)
-    show_namedtuple_diff(io, sig, called, use_color, top_level) && return nothing
+# Print `sig` with structural framing (type names, braces) in the default color,
+# matching parameters and their separating commas in gray, and the topmost
+# differing subtree(s) via `mark` (by default, `error_color`).
+function show_type_diff(io::IO, @nospecialize(sig), @nospecialize(called), use_color::Bool, top_level::Bool=true, mark=show_type_mismatch)
+    if sig === called
+        top_level && print(io, "::")
+        return show_type_match(io, sig, use_color)
+    end
+    show_namedtuple_diff(io, sig, called, use_color, top_level, mark) && return nothing
     params = descend_params(io, sig, called)
     if params === nothing
-        return show_type_mismatch(io, sig, use_color, top_level)
+        return mark(io, sig, use_color, top_level)
     end
     top_level && print(io, "::")
     sig_params, called_params, alias = params
@@ -478,13 +482,7 @@ function show_type_diff(io::IO, @nospecialize(sig), @nospecialize(called), use_c
     print(io, "{")
     for k in 1:length(sig_params)
         k > 1 && show_separator(io, use_color)
-        sp = sig_params[k]
-        cp = called_params[k]
-        if sp === cp
-            show_type_match(io, sp, use_color)
-        else
-            show_type_diff(io, sp, cp, use_color, #=top_level=#false)
-        end
+        show_type_diff(io, sig_params[k], called_params[k], use_color, #=top_level=#false, mark)
     end
     print(io, "}")
 end
@@ -508,7 +506,7 @@ function show_type_match(io::IO, @nospecialize(ty), use_color::Bool)
 end
 
 function show_namedtuple_diff(io::IO, @nospecialize(sig), @nospecialize(called),
-                              use_color::Bool, top_level::Bool)
+                              use_color::Bool, top_level::Bool, mark)
     sig isa DataType && called isa DataType || return false
     sig.name === typename(NamedTuple) && called.name === typename(NamedTuple) || return false
     length(sig.parameters) == 2 && length(called.parameters) == 2 || return false
@@ -526,14 +524,9 @@ function show_namedtuple_diff(io::IO, @nospecialize(sig), @nospecialize(called),
         show_sym(io, s_syms[i])
         sp = s_types.parameters[i]
         cp = c_types.parameters[i]
-        if sp === cp
-            sp === Any && continue   # match `show_at_namedtuple` and don't print `::Any`
-            print(io, "::")
-            show_type_match(io, sp, use_color)
-        else
-            print(io, "::")
-            show_type_diff(io, sp, cp, use_color, #=top_level=#false)
-        end
+        sp === cp === Any && continue   # match `show_at_namedtuple` and don't print `::Any`
+        print(io, "::")
+        show_type_diff(io, sp, cp, use_color, #=top_level=#false, mark)
     end
     print(io, "}")
     return true

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -333,6 +333,37 @@ function show_error_hints(io, ex, args...)
     end
 end
 
+"""
+    Experimental.print_type_diff(io::IO, a::Type, b::Type; highlight)
+
+Print `a`, highlighting the parts that differ from `b`.
+
+`a` and `b` are compared structurally, recursing into the parameters of matching
+types; the topmost differing subtrees are passed to `highlight`. Types that cannot
+be compared structurally (`Union`, `UnionAll`, `Vararg`, or differing type names)
+are passed to `highlight` whole. Only `a` is printed; `b` is the reference.
+
+`highlight(io, part)` prints the differing `part`. By default it prints `part` in
+red when `io` has `:color` set and as `!Matched{part}` otherwise, matching the
+[`MethodError`](@ref) "Closest candidates" display.
+
+# Examples
+```jldoctest
+julia> sprint(Base.Experimental.print_type_diff, @NamedTuple{a::Int, b::Char}, @NamedTuple{a::Int, b::String})
+"@NamedTuple{a::Int64, b::!Matched{Char}}"
+
+julia> sprint(io -> Base.Experimental.print_type_diff(io, Tuple{Int, Char}, Tuple{Int, String}; highlight = (io, ty) -> print(io, "<<", ty, ">>")))
+"Tuple{Int64, <<Char>>}"
+```
+"""
+function print_type_diff(io::IO, @nospecialize(a::Type), @nospecialize(b::Type);
+                         highlight=nothing)
+    use_color = get(io, :color, false)::Bool
+    mark = highlight === nothing ? Base.show_type_mismatch : (io, ty, _color, _top) -> highlight(io, ty)
+    Base.show_type_diff(io, a, b, use_color, #=top_level=#false, mark)
+    return nothing
+end
+
 # OpaqueClosure
 include("opaque_closure.jl")
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -432,6 +432,7 @@ Base.current_exceptions
 Base.@assert
 Base.Experimental.register_error_hint
 Base.Experimental.show_error_hints
+Base.Experimental.print_type_diff
 Base.ArgumentError
 Base.AssertionError
 Core.BoundsError


### PR DESCRIPTION
## What

JuliaLang/julia#61651 added machinery to highlight *where two types differ* — it's
what marks the mismatched arguments in `MethodError` "Closest candidates" lists.
That machinery is private to `errorshow.jl`. This PR exposes its entry point as
**`Base.Experimental.print_type_diff`** (next to the existing
`register_error_hint` / `show_error_hints` error-UX APIs), so custom exception
types can reuse the same highlighting in their own `showerror` methods.

```julia
print_type_diff(io::IO, a::Type, b::Type; highlight)
```

Prints `a`, highlighting the subtrees that differ from `b`. `highlight(io, part)`
controls how a differing subtree renders, defaulting to red under `:color` and
`!Matched{part}` otherwise:

```julia
julia> sprint(Base.Experimental.print_type_diff, @NamedTuple{a::Int, b::Char}, @NamedTuple{a::Int, b::String})
"@NamedTuple{a::Int64, b::!Matched{Char}}"
```

The internal recursion (`show_type_diff`) and `MethodError`'s use of it are
unchanged except for two additions that make it reusable: a `mark` callback for
rendering a differing subtree, and an `a === b` fast path so callers can diff each
element of a signature without pre-checking equality.

## Why

Custom errors that compare types currently re-implement this by hand. Motivating
case: [Reactant.jl](https://github.com/EnzymeAD/Reactant.jl) throws
`MisMatchedThunkTypeError` when a compiled function is called with arguments whose
types differ from what it was compiled for. The two type lists are large and
nearly identical, so the actual mismatch is invisible in the current message.

Because those lists are already `Tuple{...}` types, the *entire* hook reduces to two
calls:

```julia
function Base.showerror(io::IO, ::MisMatchedThunkTypeError{<:Thunk{F,…,ArgTypes},FoundTypes}) where {…}
    print(io, "The Reactant-compiled function `", F, "` was called with argument types ",
              "that don't match the signature it was compiled for.")
    print(io, "\n  Called with:  "); Base.Experimental.print_type_diff(io, FoundTypes, ArgTypes)
    print(io, "\n  Compiled for: "); Base.Experimental.print_type_diff(io, ArgTypes, FoundTypes)
end
```

In a real Lux/Reactant training loop, where a layer's state gains one extra `conv`
nesting level per step, the full (~2 KB) argument tuple is printed with every
matching argument dimmed and only the differing subtree highlighted, so the
mismatch is the only thing that stands out. The matching arguments are abbreviated
as `...` below for readability (nothing is actually elided — they print in full):

```
Called with:  Tuple{..., @NamedTuple{layer_1::@NamedTuple{conv::!Matched{@NamedTuple{conv::@NamedTuple{}}}}, layer_2::@NamedTuple{}}, ...}
Compiled for: Tuple{..., @NamedTuple{layer_1::@NamedTuple{conv::!Matched{@NamedTuple{}}}, layer_2::@NamedTuple{}}, ...}
```

(`!Matched{...}` is the no-color rendering; under `:color` that subtree is shown in `error_color` instead.)

---

This pull request was written with the assistance of generative AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
