### PR TITLE
scopedvalues: Fold reads from enclosing scopes

### DIFF
--- a/Compiler/src/ssair/passes.jl
+++ b/Compiler/src/ssair/passes.jl
@@ -567,6 +567,13 @@ function lift_comparison!(::typeof(===), compact::IncrementalCompact,
     lhs, rhs = args[2], args[3]
     vl = argextype(lhs, compact)
     vr = argextype(rhs, compact)
+    result = egal_tfunc(𝕃ₒ, vl, vr)
+    if isa(result, Const)
+        compact[idx] = result.val
+        compact[SSAValue(idx)][:type] = result
+        add_flag!(compact[SSAValue(idx)], IR_FLAG_REFINED)
+        return
+    end
     if isa(vl, Const)
         isa(vr, Const) && return
         val = rhs
@@ -1098,9 +1105,11 @@ function lift_keyvalue_get!(compact::IncrementalCompact, idx::Int, stmt::Expr, �
         KeyValueWalker(compact))
 
     if lifted_val !== nothing
-        compact[idx] = Expr(:new, wrapper_typ, lifted_val.val)
+        newexpr = Expr(:new, wrapper_typ, lifted_val.val)
+        compact[idx] = newexpr
         compact[SSAValue(idx)][:type] = wrapper_typ
         add_flag!(compact[SSAValue(idx)], IR_FLAG_REFINED)
+        refine_new_effects!(𝕃ₒ, compact, idx, newexpr)
     else
         compact[idx] = nothing
     end
@@ -1558,6 +1567,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
         line = compact[SSAValue(idx)][:line]
         if lifted_val !== nothing && !⊑(𝕃ₒ, compact[SSAValue(idx)][:type], result_t)
             compact[idx] = lifted_val.val
+            compact[SSAValue(idx)][:type] = result_t
             add_flag!(compact[SSAValue(idx)], IR_FLAG_REFINED)
         elseif lifted_val === nothing || isa(lifted_val.val, AnySSAValue)
             # Save some work in a later compaction, by inserting this into the renamer now,

--- a/Compiler/test/irpasses.jl
+++ b/Compiler/test/irpasses.jl
@@ -2174,6 +2174,25 @@ let src = code_typed1(foosvalconstprop, ())
     @test count(is_constfield_load, src.code) == 0
 end
 
+# JuliaLang/julia#58330: fold scoped value reads after setting the same key
+const sval58330 = ScopedValue(1)
+let src = code_typed1(()) do
+        @with sval58330 => 2 sval58330[]
+    end
+    is_keyvalue_get(@nospecialize x) = isexpr(x, :invoke) &&
+        singleton_type(argextype(x.args[2], src)) === Core.OptimizedGenerics.KeyValue.get
+    @test count(is_keyvalue_get, src.code) == 0
+end
+let src = code_typed1(()) do
+        with(sval58330 => 2) do
+            sval58330[]
+        end
+    end
+    is_keyvalue_get(@nospecialize x) = isexpr(x, :invoke) &&
+        singleton_type(argextype(x.args[2], src)) === Core.OptimizedGenerics.KeyValue.get
+    @test count(isinvoke(:with), src.code) == 0
+    @test count(is_keyvalue_get, src.code) == 0
+end
 # JuliaLang/julia #59548
 # Rewrite `Core._apply_iterate` to use `Core.svec` instead of `tuple` to better match
 # the codegen ABI

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -282,7 +282,7 @@ julia> with(() -> a[] * b[], a=>3, b=>4)
 12
 ```
 """
-function with(f, pair::Pair{<:AbstractScopedValue}, rest::Pair{<:AbstractScopedValue}...)
+@inline function with(f, pair::Pair{<:AbstractScopedValue}, rest::Pair{<:AbstractScopedValue}...)
     @with(pair, rest..., f())
 end
 with(@nospecialize(f)) = f()


### PR DESCRIPTION
Make `ScopedValues.with` inlineable so call-site constants reach the
optimizer. Propagate SROA type refinements immediately, fold identity
comparisons using refined types, and recompute effects after replacing
`KeyValue.get`.

Fixes JuliaLang/julia#58330

Written with AI assistance (Codex).

Co-authored-by: Codex <noreply@openai.com>
