### PR TITLE
Channel: Add batched `append!` and `take!` operations

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -455,6 +455,104 @@ function put_unbuffered(c::Channel, v)
 end
 
 """
+    append!(c::Channel, iter)
+
+Add all items from the iterable `iter` to the channel `c`, blocking while the buffer is full
+until items are taken to make room, and return `c`.
+
+When `iter` is an `AbstractArray` whose elements can be stored in `c`, items are transferred
+to a buffered channel in bulk: `append!` acquires the channel's lock once and copies as many
+items as fit in the available buffer space before releasing it, repeating until every item is
+added. This requires far fewer lock operations than calling [`put!`](@ref) for each item and
+can be substantially faster. For any other iterable, or for an unbuffered channel, `append!`
+is equivalent to calling `put!` on each item in turn.
+
+`append!` is not atomic: items may become visible to consumers before the call returns, and
+if it stops early (for example because the channel is closed or iterating `iter` throws), the
+items added so far remain in the channel.
+
+!!! note
+    On the bulk `AbstractArray` path, elements are copied while the channel's lock is held, so
+    the array should be an ordinary one whose indexing does not block or perform operations on
+    the same channel.
+
+!!! compat "Julia 1.14"
+    This method requires Julia 1.14 or later.
+
+# Examples
+```jldoctest
+julia> c = Channel{Int}(4);
+
+julia> append!(c, 1:4);
+
+julia> take!(c, 4)
+4-element Vector{Int64}:
+ 1
+ 2
+ 3
+ 4
+```
+"""
+function append!(c::Channel, iter)
+    iter === c && throw(ArgumentError("cannot `append!` a channel to itself"))
+    for x in iter
+        put!(c, x)
+    end
+    return c
+end
+# Fast path: a buffered channel can absorb an array whose elements already have an acceptable
+# type in bulk, copying straight into the buffer instead of using a per-item `put!`.
+function append!(c::Channel{T}, a::AbstractArray{<:T}) where {T}
+    isbuffered(c) && return append_buffered(c, a)
+    for x in a
+        put!(c, x)
+    end
+    return c
+end
+
+# Copy the array `a` (at linear indices `firstindex(a) .+ (0:length-1)`) into the buffer of
+# `c` in lock-amortized chunks, blocking for space as needed. `a` must already hold values of
+# an acceptable element type. Exception-safe: a failure while copying a chunk leaves `c`'s
+# buffer and `n_avail` consistent. Elements are read while the channel lock is held, so `a`
+# should be an ordinary array whose indexing does not block or reenter the channel.
+function append_buffered(c::Channel, a::AbstractArray)
+    n = length(a)
+    n == 0 && return c
+    i0 = firstindex(a)
+    pos = 0  # number of items already transferred
+    lock(c)
+    # Count all items as available up front (as `put_buffered` does for its single item) so
+    # that `n_avail`/`isfull` see a blocked batched append the same way they see blocked `put!`s.
+    _increment_n_avail(c, n)
+    try
+        while pos < n
+            while length(c.data) == c.sz_max
+                check_channel_state(c)
+                wait(c.cond_put)
+            end
+            check_channel_state(c)
+            m = min(c.sz_max - length(c.data), n - pos)
+            old = length(c.data)
+            resize!(c.data, old + m)
+            try
+                copyto!(c.data, old + 1, a, i0 + pos, m)
+            catch
+                resize!(c.data, old)  # drop the uninitialized tail if copying failed
+                rethrow()
+            end
+            # notify all, since some of the waiters may be on a `fetch` or `wait` call.
+            notify(c.cond_take, nothing, true, false)
+            pos += m
+        end
+    finally
+        # Items that were not transferred (early exit or exception) are no longer pending.
+        pos < n && _increment_n_avail(c, pos - n)
+        unlock(c)
+    end
+    return c
+end
+
+"""
     fetch(c::Channel)
 
 Waits for and returns (without removing) the first available item from the `Channel`.
@@ -550,6 +648,113 @@ function take_unbuffered(c::Channel{T}) where T
     finally
         unlock(c)
     end
+end
+
+"""
+    take!(c::Channel, n::Integer, [buffer::AbstractVector]) -> buffer
+
+Remove and return up to `n` items from the channel `c` as a vector, blocking until `n` items
+have been taken or the channel is closed. If the channel is closed before `n` items are
+available, the returned vector holds only the items that were taken. Pass `n == typemax(Int)`
+or `n == Inf` to take every item until the channel closes.
+
+For a buffered `Channel`, items are removed in batches: `take!` acquires the channel's lock
+once and removes every currently-available item (up to `n`) before releasing it, which
+requires far fewer lock operations than calling [`take!`](@ref) once per item and can be
+substantially faster.
+
+If `buffer` is given it is used to store and return the result; it must support
+[`resize!`](@ref) and is resized to the number of items taken. Otherwise a new
+`Vector{eltype(c)}` is allocated. The result is written to `buffer` while the channel's lock
+is held, so an ordinary `Vector` should be used.
+
+!!! compat "Julia 1.14"
+    This method requires Julia 1.14 or later.
+
+# Examples
+```jldoctest
+julia> c = Channel{Int}(4);
+
+julia> append!(c, 1:4);
+
+julia> take!(c, 2)
+2-element Vector{Int64}:
+ 1
+ 2
+
+julia> take!(c, 2)
+2-element Vector{Int64}:
+ 3
+ 4
+```
+"""
+function take!(c::Channel{T}, n::Integer, buffer::AbstractVector=Vector{T}()) where {T}
+    n < 0 && throw(ArgumentError("the number of items to take must be ≥ 0"))
+    return isbuffered(c) ? take_buffered(c, Int(n), buffer) : take_unbuffered(c, Int(n), buffer)
+end
+function take!(c::Channel{T}, n::AbstractFloat, buffer::AbstractVector=Vector{T}()) where {T}
+    isinf(n) && n > 0 && return take!(c, typemax(Int), buffer)
+    isinteger(n) || throw(ArgumentError("the number of items to take must be a non-negative integer or Inf"))
+    return take!(c, Int(n), buffer)
+end
+
+function take_buffered(c::Channel, n::Int, buffer::AbstractVector)
+    bi = firstindex(buffer)
+    taken = 0
+    lock(c)
+    try
+        while taken < n
+            try
+                while isempty(c.data)
+                    check_channel_state(c)
+                    wait(c.cond_take)
+                end
+            catch e
+                # a normal close means no more items are coming; return the partial batch.
+                (e isa InvalidStateException && e.state === :closed) || rethrow()
+                break
+            end
+            m = min(n - taken, length(c.data))
+            if length(buffer) < taken + m
+                resize!(buffer, taken + m)
+            end
+            copyto!(buffer, bi + taken, c.data, 1, m)
+            deleteat!(c.data, 1:m)
+            _increment_n_avail(c, -m)
+            # notify all: up to `m` slots are now free for blocked `put!`/`append!` tasks.
+            notify(c.cond_put, nothing, true, false)
+            taken += m
+        end
+    finally
+        unlock(c)
+    end
+    # Trim after releasing the lock so a throwing `resize!` (e.g. a non-resizable buffer)
+    # cannot leak the channel lock.
+    length(buffer) == taken || resize!(buffer, taken)
+    return buffer
+end
+
+# 0-size channel
+function take_unbuffered(c::Channel{T}, n::Int, buffer::AbstractVector) where {T}
+    bi = firstindex(buffer)
+    taken = 0
+    while taken < n
+        local v::T
+        try
+            v = take_unbuffered(c)
+        catch e
+            (e isa InvalidStateException && e.state === :closed) || rethrow()
+            break
+        end
+        if bi + taken <= lastindex(buffer)
+            buffer[bi + taken] = v
+        else
+            push!(buffer, v)
+        end
+        taken += 1
+    end
+    length(buffer) == taken || resize!(buffer, taken)
+    return buffer
 end
 
 """

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -641,6 +641,160 @@ end
     @test push!(c, nothing) === c
 end
 
+# An AbstractArray of length `len` whose linear getindex throws once index `bad` is reached;
+# used to exercise the exception-safety of the bulk `append!` fast path.
+struct ThrowingArray <: AbstractVector{Int}
+    len::Int
+    bad::Int
+end
+Base.size(a::ThrowingArray) = (a.len,)
+Base.IndexStyle(::Type{ThrowingArray}) = IndexLinear()
+Base.getindex(a::ThrowingArray, i::Int) = i < a.bad ? i : error("boom")
+
+# Batched channel operations: append!(c, iter) and take!(c, n[, buffer])
+@testset "batch append!/take!" begin
+    @testset "append!" begin
+        # fits in buffer
+        let c = Channel{Int}(4)
+            @test append!(c, 1:4) === c
+            @test Base.n_avail(c) == 4
+            @test [take!(c) for _ in 1:4] == [1, 2, 3, 4]
+        end
+        # more items than buffer space blocks until drained
+        let c = Channel{Int}(3) do ch; append!(ch, 1:10); end
+            @test collect(c) == collect(1:10)
+        end
+        # element conversion (array eltype not <: channel eltype)
+        let c = Channel{Float64}(4)
+            append!(c, Int[1, 2, 3]); close(c)
+            @test collect(c) == [1.0, 2.0, 3.0]
+        end
+        # generic iterator without length, needing to block on a small buffer
+        let c = Channel{Int}(4) do ch; append!(ch, (2i for i in 1:10)); end
+            @test collect(c) == [2i for i in 1:10]
+        end
+        # array fast path into Channel{Any}
+        let c = Channel{Any}(4)
+            append!(c, [1, 2, 3]); close(c)
+            @test collect(c) == Any[1, 2, 3]
+        end
+        # unbuffered channel
+        let c = Channel{Int}() do ch; append!(ch, 1:3); end
+            @test collect(c) == [1, 2, 3]
+        end
+        # channel-to-channel transfer over a mix of buffer sizes
+        for (b1, b2) in Iterators.product((0, 3, 5), (0, 3, 5))
+            src = Channel{Int}(b1) do ch; append!(ch, 1:5); end
+            dst = Channel{Int}(b2) do ch; append!(ch, src); end
+            @test collect(dst) == [1, 2, 3, 4, 5]
+        end
+        # appending to a closed channel throws
+        let c = Channel{Int}(2)
+            close(c)
+            @test_throws InvalidStateException append!(c, 1:2)
+        end
+        # empty iterators are a no-op
+        let c = Channel{Int}(2)
+            @test append!(c, Int[]) === c
+            @test append!(c, 1:0) === c
+            @test Base.n_avail(c) == 0
+        end
+        # appending a channel to itself is rejected
+        let c = Channel{Int}(2)
+            @test_throws ArgumentError append!(c, c)
+        end
+    end
+
+    @testset "take!" begin
+        let c = Channel{Int}(4)
+            append!(c, 1:4)
+            @test take!(c, 0) == Int[]
+            @test take!(c, 2) == [1, 2]
+            @test Base.n_avail(c) == 2
+            @test take!(c, 1) == [3]
+            close(c)
+            @test take!(c, 5) == [4]      # closed: returns the partial remainder
+        end
+        # closing yields the partial batch
+        let c = Channel{Int}(3) do ch; append!(ch, 1:3); end
+            @test take!(c, 10) == [1, 2, 3]
+        end
+        # provided buffer is reused, grown, and trimmed
+        let c = Channel{Int}(8) do ch; append!(ch, 1:5); end
+            buf = Vector{Int}(undef, 2)
+            r = take!(c, 100, buf)
+            @test r === buf
+            @test r == [1, 2, 3, 4, 5]
+        end
+        # take all until close with Inf / typemax
+        for n in (Inf, typemax(Int))
+            c = Channel{Int}(3) do ch; append!(ch, 1:3); end
+            @test take!(c, n) == [1, 2, 3]
+        end
+        # unbuffered channel
+        let c = Channel{Int}() do ch; append!(ch, 1:3); end
+            @test take!(c, 3) == [1, 2, 3]
+        end
+        # invalid n
+        @test_throws ArgumentError take!(Channel{Int}(1), -1)
+        @test_throws ArgumentError take!(Channel{Int}(1), 1.5)
+    end
+
+    @testset "n_avail and exception safety" begin
+        # a blocked bulk append counts its pending items in n_avail, like blocked put!s
+        let c = Channel{Int}(3)
+            t = @async append!(c, collect(1:10))
+            @test timedwait(() -> Base.n_avail(c) == 10, 5.0) === :ok
+            @test Base.isfull(c)
+            out = Int[]
+            while length(out) < 10
+                append!(out, take!(c, 10))
+            end
+            wait(t)
+            @test out == collect(1:10)
+            @test Base.n_avail(c) == 0
+        end
+        # appending to a closed channel leaves n_avail unchanged
+        let c = Channel{Int}(5)
+            put!(c, 99); close(c)
+            @test_throws InvalidStateException append!(c, 1:3)
+            @test Base.n_avail(c) == 1
+        end
+        # a failure midway through a bulk copy leaves the buffer and n_avail consistent
+        let c = Channel{Int}(10)
+            @test_throws ErrorException append!(c, ThrowingArray(5, 3))
+            @test length(c.data) == Base.n_avail(c) == 0
+        end
+    end
+
+    @testset "concurrent producers/consumers" begin
+        # round-trip many items through a small buffer using batches across several tasks
+        item_n, batch, nt = 2000, 50, 4
+        ch = Channel{Int}(16)
+        producers = [Threads.@spawn begin
+            i = 1
+            while i <= item_n
+                hi = min(i + batch - 1, item_n)
+                append!(ch, i:hi)
+                i = hi + 1
+            end
+        end for _ in 1:nt]
+        got = Threads.Atomic{Int}(0)
+        checksum = Threads.Atomic{Int}(0)
+        consumers = [Threads.@spawn while true
+            v = take!(ch, batch)
+            isempty(v) && break
+            Threads.atomic_add!(got, length(v))
+            Threads.atomic_add!(checksum, sum(v))
+        end for _ in 1:nt]
+        wait.(producers)
+        close(ch)
+        wait.(consumers)
+        @test got[] == nt * item_n
+        @test checksum[] == nt * sum(1:item_n)
+    end
+end
+
 # Channel `show`
 let c = Channel(3)
     @test repr(c) == "Channel{Any}(3)"


### PR DESCRIPTION
Add `append!(c::Channel, iter)` and `take!(c::Channel, n[, buffer])` for moving many items through a channel at once.

For a buffered channel, both operations acquire the channel lock once and copy a whole run of items into or out of the internal buffer before releasing it, rather than locking, notifying, and updating bookkeeping per item as a `put!`/`take!` loop does. This drastically reduces the number of lock and notify operations and is substantially faster when throughput matters. Bulk transfer is restricted to the cases where it is safe and beneficial: `append!` only batches when the source is an `AbstractArray` whose elements already have an acceptable type, and otherwise falls back to a plain `put!` loop with identical semantics; `take!(c, n)` batches drains from any buffered channel.

The operations are not atomic: items may become visible to consumers before the call returns, and a batched `take!` returns however many items were available when the channel closes. Both are exception-safe, leaving the channel's buffer and availability count consistent if iterating the source or copying an element throws.

This revives the idea explored in JuliaLang/julia#56473.

## Benchmarks

Measured on this branch (`julia 1.14.0-DEV`, single thread). Each figure is the minimum wall time over 20 trials, each on a fresh channel sized so nothing blocks — isolating the per-item overhead the bulk path removes.

**Producer — `append!(c, data)` vs a per-item `put!` loop:**

| N | `put!` loop | `append!` | speedup |
|--:|--:|--:|--:|
| 1,000 | 13.4 µs | 1.5 µs | **8.9×** |
| 10,000 | 125.3 µs | 3.5 µs | **35.4×** |
| 100,000 | 1227 µs | 13.5 µs | **90.9×** |

**Consumer — `take!(c, n)` vs a per-item `take!` loop:**

| N | `take!` loop | `take!(c, n)` | speedup |
|--:|--:|--:|--:|
| 1,000 | 11.1 µs | 1.9 µs | **5.8×** |
| 10,000 | 112.5 µs | 3.5 µs | **32.2×** |
| 100,000 | 1122 µs | 13.0 µs | **86.1×** |

Even versus the best you can already do without these methods — manually grabbing the lock once and `push!`-ing in a loop — the bulk copy is still several times faster, because it skips the per-item `notify`/bookkeeping and uses a single `copyto!`:

| N | hand-rolled lock-once loop | `append!` | speedup |
|--:|--:|--:|--:|
| 1,000 | 4.5 µs | 1.5 µs | **2.9×** |
| 10,000 | 29.8 µs | 2.7 µs | **11.2×** |
| 100,000 | 265.3 µs | 14.2 µs | **18.7×** |

The headline gains are on throughput in an uncontended buffer, which is what the per-item overhead dominates. Under heavy consumer contention the producer-side change still helps by cutting wakeup traffic (one `notify` per chunk instead of per item): an 8-thread test feeding 50k items through a 64-slot buffer to M competing consumers (which still take per-item) showed a steady ~1.2–1.3× from M=2 to M=32.

<details><summary>Reproduce</summary>

```julia
bestof(reps, setup, body) = minimum(((c = setup(); GC.gc(); @elapsed body(c)) for _ in 1:reps))

fill_loop!(c, data) = (for x in data; put!(c, x); end)
drain_loop!(c, n)   = (for _ in 1:n; take!(c); end)

for N in (10^3, 10^4, 10^5)
    data = collect(1:N)
    tloop = bestof(20, () -> Channel{Int}(N), c -> fill_loop!(c, data))
    tapp  = bestof(20, () -> Channel{Int}(N), c -> append!(c, data))
    mk()  = (c = Channel{Int}(N); append!(c, data); c)
    tdl   = bestof(20, mk, c -> drain_loop!(c, N))
    tdb   = bestof(20, mk, c -> take!(c, N))
    println("N=$N  put!-loop=$(round(tloop*1e6;digits=1))µs append!=$(round(tapp*1e6;digits=1))µs ($(round(tloop/tapp;digits=1))x)",
            "  take!-loop=$(round(tdl*1e6;digits=1))µs take!(c,n)=$(round(tdb*1e6;digits=1))µs ($(round(tdl/tdb;digits=1))x)")
end
```
</details>

---

This pull request was written with the assistance of generative AI (Claude Code).