### PR TITLE
inference: fold TypeVar components in Union apply_type_tfunc

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1846,9 +1846,7 @@ function apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospe
     if headtype === Union
         # the union is valid as long as all components are Types or TypeVars
         for i = 2:length(argtypes)
-            ai = widenconditional(argtypes[i])
-            isa(ai, PartialTypeVar) && continue
-            ⊑(𝕃, ai, Union{Type,TypeVar}) || return false
+            ⊑(𝕃, widenconditional(argtypes[i]), Union{Type,TypeVar}) || return false
         end
         return true
     end

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1938,12 +1938,8 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
             ai = argtypes[i]
             if isa(ai, Const)
                 if !isa(ai.val, Type)
-                    if isa(ai.val, TypeVar)
-                        hasnonType = true
-                        mayTypeVar = true
-                    else
-                        return Bottom
-                    end
+                    isa(ai.val, TypeVar) || return Bottom
+                    mayTypeVar = true
                 end
             elseif isa(ai, PartialTypeVar)
                 mayTypeVar = true
@@ -1982,14 +1978,15 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
                 hasvaluetv = true
             else
                 aty = (ai::Const).val
+                hasvaluetv |= isa(aty, TypeVar)
             end
             ty = Union{ty, aty}
         end
         allconst && return Const(ty)
         isa(ty, Type) && return Type{ty}
         # the union collapsed to a bare TypeVar (e.g. Union{Union{}, T}); if it is a
-        # TypeVar value from a `PartialTypeVar` component, the runtime result is the
-        # TypeVar object itself, whereas a symbolic TypeVar from a `Type{B}`
+        # TypeVar value from a Const/PartialTypeVar component, the runtime result is
+        # the TypeVar object itself, whereas a symbolic TypeVar from a `Type{B}`
         # component stands for a type equal to it
         hasvaluetv || return Type{ty}
         hassymbolictv && return Union{Type,TypeVar}

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1843,9 +1843,15 @@ function apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospe
     else
         return false
     end
-    # We know the apply_type is well formed. Otherwise our rt would have been
-    # Bottom (or Type).
-    (headtype === Union) && return true
+    if headtype === Union
+        # the union is valid as long as all components are Types or TypeVars
+        for i = 2:length(argtypes)
+            ai = widenconditional(argtypes[i])
+            isa(ai, PartialTypeVar) && continue
+            ⊑(𝕃, ai, Union{Type,TypeVar}) || return false
+        end
+        return true
+    end
     headtype === TypeEq && return typeeq_apply_type_nothrow(𝕃, argtypes)
     headtype === Core.TypeEgal && return typeegal_apply_type_nothrow(𝕃, argtypes)
     isa(rt, Const) && return true
@@ -1927,32 +1933,36 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
     if headtype === Union
         largs == 1 && return Const(Bottom)
         hasnonType = false
+        mayTypeVar = false # could the result collapse to a bare TypeVar (e.g. Union{Union{}, T})?
         for i = 2:largs
             ai = argtypes[i]
             if isa(ai, Const)
                 if !isa(ai.val, Type)
                     if isa(ai.val, TypeVar)
                         hasnonType = true
+                        mayTypeVar = true
                     else
                         return Bottom
                     end
                 end
-            else
-                if !(isTypeEq(ai) || (isTypeEgal(ai) && type_parameter(ai) isa Type))
-                    if !isa(ai, Type) || hasintersect(ai, Type) || hasintersect(ai, TypeVar)
-                        hasnonType = true
-                    else
-                        return Bottom
-                    end
+            elseif isa(ai, PartialTypeVar)
+                mayTypeVar = true
+            elseif !(isTypeEq(ai) || (isTypeEgal(ai) && type_parameter(ai) isa Type))
+                if !isa(ai, Type) || hasintersect(ai, Type) || hasintersect(ai, TypeVar)
+                    hasnonType = true
+                    mayTypeVar |= !isa(ai, Type) || hasintersect(ai, TypeVar)
+                else
+                    return Bottom
                 end
             end
         end
         if largs == 2 # Union{T} --> T
             return tmeet(widenconst(argtypes[2]), Union{Type,TypeVar})
         end
-        hasnonType && return Type
+        hasnonType && return mayTypeVar ? Union{Type,TypeVar} : Type
         ty = Union{}
         allconst = true
+        hasvaluetv = hassymbolictv = false
         for i = 2:largs
             ai = argtypes[i]
             if isTypeEgal(ai)
@@ -1963,12 +1973,27 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
                 # way datatype instantiation does (`Union{S}` is `S` itself), so
                 # an `==`-only argument leaves the result only `==`-certain
                 allconst = false
+                hassymbolictv |= isa(aty, TypeVar)
+            elseif isa(ai, PartialTypeVar)
+                # the bounds of this TypeVar are known precisely, but the runtime
+                # TypeVar object is created fresh, so its identity is not constant
+                aty = ai.tv
+                allconst = false
+                hasvaluetv = true
             else
                 aty = (ai::Const).val
             end
             ty = Union{ty, aty}
         end
-        return allconst ? Const(ty) : Type{ty}
+        allconst && return Const(ty)
+        isa(ty, Type) && return Type{ty}
+        # the union collapsed to a bare TypeVar (e.g. Union{Union{}, T}); if it is a
+        # TypeVar value from a `PartialTypeVar` component, the runtime result is the
+        # TypeVar object itself, whereas a symbolic TypeVar from a `Type{B}`
+        # component stands for a type equal to it
+        hasvaluetv || return Type{ty}
+        hassymbolictv && return Union{Type,TypeVar}
+        return TypeVar
     end
     if headtype === TypeEq
         return typeeq_apply_type_tfunc(𝕃, argtypes)

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -1926,7 +1926,11 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
     end
     largs = length(argtypes)
     if largs > 1 && isvarargtype(argtypes[end])
-        return isvarargtype(headtype) ? TypeofVararg : Type
+        isvarargtype(headtype) && return TypeofVararg
+        # a `Union` head can collapse to a bare `TypeVar` (`Union{T}` is `T`), which
+        # is not a `Type`, so the result cannot be pinned down to `Type` here
+        headtype === Union && return Union{Type, TypeVar}
+        return Type
     end
     if headtype === Union
         largs == 1 && return Const(Bottom)
@@ -1942,9 +1946,10 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
             elseif isa(ai, PartialTypeVar)
                 mayTypeVar = true
             elseif !(isTypeEq(ai) || (isTypeEgal(ai) && type_parameter(ai) isa Type))
-                if !isa(ai, Type) || hasintersect(ai, Type) || hasintersect(ai, TypeVar)
+                maytv = !isa(ai, Type) || hasintersect(ai, TypeVar)
+                if maytv || hasintersect(ai, Type)
                     hasnonType = true
-                    mayTypeVar |= !isa(ai, Type) || hasintersect(ai, TypeVar)
+                    mayTypeVar |= maytv
                 else
                     return Bottom
                 end
@@ -1956,7 +1961,7 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
         hasnonType && return mayTypeVar ? Union{Type,TypeVar} : Type
         ty = Union{}
         allconst = true
-        hasvaluetv = hassymbolictv = false
+        hassymbolictv = false
         for i = 2:largs
             ai = argtypes[i]
             if isTypeEgal(ai)
@@ -1973,20 +1978,18 @@ function apply_type_tfunc(𝕃::AbstractLattice, argtypes::Vector{Any};
                 # TypeVar object is created fresh, so its identity is not constant
                 aty = ai.tv
                 allconst = false
-                hasvaluetv = true
             else
                 aty = (ai::Const).val
-                hasvaluetv |= isa(aty, TypeVar)
             end
             ty = Union{ty, aty}
         end
         allconst && return Const(ty)
         isa(ty, Type) && return Type{ty}
         # the union collapsed to a bare TypeVar (e.g. Union{Union{}, T}); if it is a
-        # TypeVar value from a Const/PartialTypeVar component, the runtime result is
-        # the TypeVar object itself, whereas a symbolic TypeVar from a `Type{B}`
-        # component stands for a type equal to it
-        hasvaluetv || return Type{ty}
+        # TypeVar value from a Const/PartialTypeVar component (tracked by `mayTypeVar`),
+        # the runtime result is the TypeVar object itself, whereas a symbolic TypeVar
+        # from a `Type{B}` component stands for a type equal to it
+        mayTypeVar || return Type{ty}
         hassymbolictv && return Union{Type,TypeVar}
         return TypeVar
     end

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -528,9 +528,9 @@ end
         end
         return false
     elseif isa(a, PartialTypeVar)
-        a === b && return true
+        (a === b || b === TypeVar) && return true
         # the instance of a PartialTypeVar is a runtime TypeVar object
-        return isa(b, Type) && ⊑(widenlattice(lattice), TypeVar, b)
+        return isa(b, Type) && ⊑(widenlattice(lattice), widenconst(a), b)
     elseif isa(b, PartialTypeVar)
         return false
     end

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -528,7 +528,9 @@ end
         end
         return false
     elseif isa(a, PartialTypeVar)
-        return b === TypeVar || a === b
+        a === b && return true
+        # the instance of a PartialTypeVar is a runtime TypeVar object
+        return isa(b, Type) && ⊑(widenlattice(lattice), TypeVar, b)
     elseif isa(b, PartialTypeVar)
         return false
     end

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -4459,6 +4459,14 @@ const DenseIdx = Union{IntRange,Integer}
 
 # Non uniformity in expressions with PartialTypeVar
 @test Compiler.:⊑(Compiler.PartialTypeVar(TypeVar(:N), true, true), TypeVar)
+# a PartialTypeVar is a runtime TypeVar object, so it is below any wider type too
+let ptv = Compiler.PartialTypeVar(TypeVar(:N), true, true)
+    @test Compiler.:⊑(ptv, Union{Type,TypeVar})
+    @test Compiler.:⊑(ptv, Any)
+    @test !Compiler.:⊑(ptv, Type)
+    @test !Compiler.:⊑(ptv, Union{})
+    @test !Compiler.:⊑(ptv, Compiler.PartialTypeVar(TypeVar(:N), true, true))
+end
 let N = TypeVar(:N)
     𝕃 = Compiler.SimpleInferenceLattice.instance
     argtypes = Any[Compiler.Const(NTuple),

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7530,6 +7530,12 @@ let apply_type_tfunc = Compiler.apply_type_tfunc
     # unknown components may turn out to be TypeVars at runtime
     @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Nothing), Any]) == Union{Type,TypeVar}
     @test !apply_type_nothrow(𝕃, Any[Const(Union), Const(Nothing), Any], Union{Type,TypeVar})
+    # a `Const` TypeVar has known object identity, so the union folds to a `Const`
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Nothing), Const(tv)]) === Const(Union{Nothing,tv})
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Union{}), Const(tv)]) === Const(tv)
+    @test apply_type_nothrow(𝕃, Any[Const(Union), Const(Nothing), Const(tv)], Const(Union{Nothing,tv}))
+    # but mixed with unknown components, the result may still be a bare TypeVar
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Type, Const(tv)]) == Union{Type,TypeVar}
     # a symbolic TypeVar from a `Type{B}` component stands for a type equal to it,
     # so the collapsed result is a `Type`, not the TypeVar object
     B = TypeVar(:B, Union{}, Integer)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7549,6 +7549,10 @@ let apply_type_tfunc = Compiler.apply_type_tfunc
     B = TypeVar(:B, Union{}, Integer)
     @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Union{}), Type{B}]) === Type{B}
     @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Nothing), Type{B}]) === Type{Union{Nothing,B}}
+    # a `Union` head with a trailing vararg can still collapse to a bare TypeVar, so it
+    # must not be pinned down to `Type` (the non-vararg path widens likewise)
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Nothing), Vararg{Any}]) == Union{Type,TypeVar}
+    @test apply_type_tfunc(𝕃, Any[Const(Vector), Vararg{Any}]) === Type
 end
 issue53917(v; y::Union{Nothing,<:Integer}=nothing) = isnothing(y) ? v[1] : v[y]
 let src = code_typed1(Core.kwcall, (NamedTuple{(:y,),Tuple{Int}}, typeof(issue53917), Vector{Int}))

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -7515,6 +7515,35 @@ let apply_type_tfunc = Compiler.apply_type_tfunc
     @test apply_type_tfunc(𝕃, Any[Const(Vector), Union{Type{Int},Type{Nothing}}]) == Union{Core.TypeEgal{Vector{Int}},Core.TypeEgal{Vector{Nothing}}}
 end
 
+# issue #53917: `Union` head `apply_type_tfunc` precision for `PartialTypeVar` components,
+# so that kwarg types like `Union{Nothing,<:Integer}` are not rebuilt on every call
+let apply_type_tfunc = Compiler.apply_type_tfunc
+    apply_type_nothrow = Compiler.apply_type_nothrow
+    𝕃 = Compiler.fallback_lattice
+    Const = Core.Const
+    tv = TypeVar(:T, Union{}, Integer)
+    ptv = Compiler.PartialTypeVar(tv, true, true)
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Nothing), ptv]) == Type{Union{Nothing,tv}}
+    @test apply_type_nothrow(𝕃, Any[Const(Union), Const(Nothing), ptv], Type{Union{Nothing,tv}})
+    # the union may collapse to the bare TypeVar object, which is not a `Type`
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Union{}), ptv]) === TypeVar
+    # unknown components may turn out to be TypeVars at runtime
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Nothing), Any]) == Union{Type,TypeVar}
+    @test !apply_type_nothrow(𝕃, Any[Const(Union), Const(Nothing), Any], Union{Type,TypeVar})
+    # a symbolic TypeVar from a `Type{B}` component stands for a type equal to it,
+    # so the collapsed result is a `Type`, not the TypeVar object
+    B = TypeVar(:B, Union{}, Integer)
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Union{}), Type{B}]) === Type{B}
+    @test apply_type_tfunc(𝕃, Any[Const(Union), Const(Nothing), Type{B}]) === Type{Union{Nothing,B}}
+end
+issue53917(v; y::Union{Nothing,<:Integer}=nothing) = isnothing(y) ? v[1] : v[y]
+let src = code_typed1(Core.kwcall, (NamedTuple{(:y,),Tuple{Int}}, typeof(issue53917), Vector{Int}))
+    # the `isa` check against the kwarg type should fold away, leaving no
+    # runtime TypeVar/UnionAll construction in the keyword sorter
+    @test count(iscall((src, Core._typevar)), src.code) == 0
+    @test count(stmt -> Meta.isexpr(stmt, :foreigncall), src.code) == 0
+end
+
 @test Base.infer_return_type((Bool,Int,)) do b, y
     x = b ? 1 : missing
     inner = y -> x + y

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -197,7 +197,10 @@ Float64
 """
 function promote_typejoin(@nospecialize(a), @nospecialize(b))
     c = typejoin(_promote_typesubtract(a), _promote_typesubtract(b))
-    return Union{a, b, c}
+    # the arguments are always types, so the `Union` is too; inference alone can
+    # only conclude `Union{Type,TypeVar}` here, since a `Union` of a lone
+    # `TypeVar` argument would collapse to the `TypeVar` itself
+    return Union{a, b, c}::Type
 end
 _promote_typesubtract(@nospecialize(a)) =
     a === Any ? a :


### PR DESCRIPTION
Keyword arguments declared with sugared unions like `Union{Nothing,<:Integer}` cost several allocations (~200ns) per call, because lowering splices the declared-type expression into the keyword sorter for the `isa` check, and the `Union` head of `apply_type_tfunc` had no `PartialTypeVar` case — so the runtime `_typevar`/`apply_type`/`UnionAll` construction never folded.

This teaches the `Union` branch of `apply_type_tfunc` to:
- fold `PartialTypeVar` components into `Type{Union{..., tv}}`, preserving the TypeVar identity needed for the later `abstract_call_unionall` rewrap, after which the `isa` guard folds and the construction is DCE'd;
- fold `Const` TypeVar components to `Const` (their object identity is known);
- handle the collapse case soundly: `Union{Union{}, tv}` is the bare `TypeVar` object at runtime, not a `Type`, so results distinguish value TypeVars (`TypeVar`), symbolic TypeVars from `Type{B}` components (`Type{ty}`), and unknown components (`Union{Type,TypeVar}`). The pre-existing `hasnonType → Type` shortcut was unsound for exactly this reason.

`apply_type_nothrow` now validates `Union` components against `Union{Type,TypeVar}` instead of blindly returning `true`, and `⊑(::ConstsLattice)` learns to compare `PartialTypeVar` against types wider than plain `TypeVar`.

The merge with master (past #62001's `TypeEgal` kind) surfaced one semantic interaction: the sound `Union{Type,TypeVar}` widening reaches `promote_typejoin` (whose `typejoin` call infers `Any`), degrading `eltype(::Tuple)` inference now that `_compute_eltype` is reachable in the equality-keyed world. Since `promote_typejoin` always returns a `Type` at runtime, a `::Type` assertion on its return value restores the precision.

With this, the keyword sorter for a `Union{Nothing,<:Integer}` kwarg contains no `_typevar` calls or foreigncalls, and both repros from the issue run allocation-free.

Fixes JuliaLang/julia#53917

This pull request was written with the assistance of generative AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)