### PR TITLE
method: normalize kwcall callee self-type to the equality kind

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -1297,6 +1297,13 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
         jl_svecset(new_atypes, 0, ft);
         atypes = new_atypes;
     }
+    else if (jl_kwcall_type && ft == (jl_value_t*)jl_kwcall_type && nargs >= 3 &&
+             jl_is_typeegal(jl_svecref(atypes, 2))) {
+        // likewise for a keyword sorter, whose callee self-type is argument 2
+        new_atypes = jl_svec_copy(atypes);
+        jl_svecset(new_atypes, 2, jl_wrap_Type(jl_typeegal_T(jl_svecref(new_atypes, 2))));
+        atypes = new_atypes;
+    }
 
     argtype = jl_apply_tuple_type(atypes, 1);
     if (!jl_is_datatype(argtype))

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -400,3 +400,13 @@ function f50518(xs...=["a", "b", "c"]...; debug=false)
     return xs[1]
 end
 @test f50518() == f50518(;debug=false) == "a"
+
+# issue #62277
+struct Issue62277
+    S::Vector{Symbol}
+    Issue62277(s::Vector{Symbol}; cached=false) = new(s)
+end
+Issue62277(s::AbstractVector{<:Union{Char,AbstractString,Symbol}}; cached=false) =
+    Issue62277(Symbol.(s); cached)
+@test Issue62277([:a, :b]; cached=false).S == [:a, :b]
+@test Issue62277(['a', 'b']).S == [:a, :b]


### PR DESCRIPTION
Fixes the `kwcall` dispatch ambiguity reported in JuliaLang/julia#62277, where an inner and an outer keyword constructor become mutually ambiguous on nightly:

```julia
struct SomeStruct
    S::Vector{Symbol}
    function SomeStruct(s::Vector{Symbol}; cached::Bool = false)
        @assert !cached
        return new(s)
    end
end
SomeStruct(s::AbstractVector{<:Union{Char, AbstractString, Symbol}}; cached::Bool = false) = SomeStruct(Symbol.(s), cached = cached)

julia> SomeStruct([Symbol(x) for x in 1:5]; cached=false)
ERROR: MethodError: kwcall(::@NamedTuple{cached::Bool}, ::Core.TypeEgal{SomeStruct}, ::Vector{Symbol}) is ambiguous.
```

## Root cause

A keyword sorter is defined as `kwcall(::NamedTuple, callee, args...)`, and lowering spells the `callee` self-type with `Core.Typeof`. Since the `TypeEgal` kind was added (JuliaLang/julia#62001), `Core.Typeof` of a type value yields the egality `Core.TypeEgal{T}` kind rather than the equality `Type{T}` kind. `jl_method_def` already normalizes that back to `Type{T}` — but only for the method's own function argument at position 0. The keyword sorter carries the real callee at argument 2, so:

- the outer method's sorter kept `Core.TypeEgal{SomeStruct}` (egality)
- the inner constructor's sorter used `Type{SomeStruct}` (equality, because lowering spells inner constructors literally as `Type{T}`)

Since `TypeEgal{T} <: Type{T}` but not vice versa, the outer sorter has the more specific self-type but the less specific `s` argument, and the inner has the reverse — a cross-cutting ambiguity. The plain (non-keyword) methods are unaffected because both consistently normalize to `Type{SomeStruct}`.

## Fix

Extend the existing position-0 normalization in `jl_method_def` to also normalize the keyword sorter's callee self-type (argument 2, identified exactly as the existing debug-name logic already does), so the sorter and its primary method agree on the callee kind.

Validated: the reduced case dispatches correctly, both sorter signatures become `Type{SomeStruct}`, normal-function and type-valued-callee keyword methods are unaffected, `keywordargs` and `ambiguous` test suites pass, and the clang static analysis / GC-rooting checker are clean.

This pull request was written with the assistance of generative AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)