### PR TITLE
show: user-facing display of `Core.TypeEgal` arguments in errors and call signatures

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -785,10 +785,16 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs=[])
                         show_separator(iob, use_color)
                     end
                     if k == 1 && Base.isvarargtype(sigtype)
-                        # There wasn't actually a mismatch - the method match failed for
-                        # some other reason, e.g. world age. Just print the sigstr.
-                        print(iob, sigstr...)
-                    elseif get(io, :color, false)::Bool
+                        # There wasn't actually a mismatch - the trailing vararg can
+                        # accept zero arguments (or the method match failed for some
+                        # other reason, e.g. world age), so print the sigstr like a
+                        # matching parameter rather than in the error color.
+                        if use_color
+                            print(iob, text_colors[:light_black], sigstr..., text_colors[:default])
+                        else
+                            print(iob, sigstr...)
+                        end
+                    elseif use_color
                         let sigstr=sigstr
                             Base.with_output_color(Base.error_color(), iob) do iob
                                 print(iob, "::", sigstr...)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -246,7 +246,7 @@ function show_convert_error(io::IO, ex::MethodError, arg_types_param)
     if T === nothing
         print(io, "First argument to `convert` must be a Type, got ", ex.args[1])
     else
-        p2 = arg_types_param[2]
+        p2 = argtype_for_display(arg_types_param[2])
         print_one_line = isa(T, DataType) && isa(p2, DataType) && T.name != p2.name
         printstyled(io, "Cannot `convert` an object of type ")
         print_one_line || printstyled(io, "\n  ")

--- a/base/show.jl
+++ b/base/show.jl
@@ -1005,6 +1005,18 @@ function show_unionaliases(io::IO, x::Union)
 end
 
 function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
+    if x isa Core.TypeEgal
+        # the compact `Core.Typeof(X)` spelling, with the canonical kind name
+        # spelled out alongside, mirroring the `Type{X} (alias for TypeEq{X})`
+        # display of the equality kind
+        show(IOContext(io, :compact => true), x)
+        if !(get(io, :compact, false)::Bool)
+            printstyled(io, " (alias for "; color = :light_black)
+            printstyled(IOContext(io, :compact => false), x, color = :light_black)
+            printstyled(io, ")"; color = :light_black)
+        end
+        return
+    end
     if !print_without_params(x)
         if make_typealias(x, io) !== nothing || (unwrap_unionall(x) isa Union && x <: make_typealiases(x)[2])
             show(IOContext(io, :compact => true), x)
@@ -1029,10 +1041,22 @@ function show(io::IO, ::MIME"text/plain", @nospecialize(x::Type))
     end
 end
 
+# Unlike `TypeEq`, the egality kind has no user-level braces syntax; its familiar
+# spelling is the constructor call `Core.Typeof(X)`, which round-trips
+# (`Core.Typeof(X) === Core.TypeEgal{X}` for any closed `X`) analogously to
+# `typeof(sin)` for function singleton types. Normal (compact) printing uses that
+# spelling; non-compact contexts (e.g. the REPL's `text/plain` display) show the
+# canonical kind name `Core.TypeEgal{X}` instead.
 function show_typeegal(io::IO, @nospecialize(x::Core.TypeEgal))
-    print(io, "Core.TypeEgal{")
-    show(io, type_parameter(x))
-    print(io, "}")
+    if get(io, :compact, true)::Bool
+        print(io, "Core.Typeof(")
+        show(io, type_parameter(x))
+        print(io, ")")
+    else
+        print(io, "Core.TypeEgal{")
+        show(io, type_parameter(x))
+        print(io, "}")
+    end
 end
 function show(io::IO, @nospecialize(x::Core.AnyType))
     if x isa Core.TypeofBottom

--- a/base/show.jl
+++ b/base/show.jl
@@ -2608,6 +2608,12 @@ function print_within_stacktrace(io, s...; color=:normal, bold=false)
     end
 end
 
+# Display a `Core.TypeEgal{X}` argument (the `Core.Typeof` of a closed type) in
+# call position with the `Type{X}` spelling of the method signatures a user
+# would write to accept it — the same identification `descend_params` makes in
+# errorshow.jl. Outside call display the kind shows as `Core.Typeof(X)`.
+argtype_for_display(@nospecialize t) = t isa Core.TypeEgal ? Type{type_parameter(t)} : t
+
 function show_tuple_as_call(out::IO, name::Symbol, sig::Type;
                             demangle=false, kwargs=nothing, argnames=nothing,
                             qualified=false, hasfirst=true)
@@ -2641,7 +2647,7 @@ function show_tuple_as_call(out::IO, name::Symbol, sig::Type;
             print_within_stacktrace(io, argnames[i]; color=:light_black)
         end
         print(io, "::")
-        print_type_bicolor(env_io, sig[i]; use_color = get(io, :backtrace, false)::Bool)
+        print_type_bicolor(env_io, argtype_for_display(sig[i]); use_color = get(io, :backtrace, false)::Bool)
     end
     if kwargs !== nothing
         print(io, "; ")
@@ -2655,7 +2661,7 @@ function show_tuple_as_call(out::IO, name::Symbol, sig::Type;
                 print(io, "...")
             else
                 print(io, "::")
-                print_type_bicolor(io, t; use_color = get(io, :backtrace, false)::Bool)
+                print_type_bicolor(io, argtype_for_display(t); use_color = get(io, :backtrace, false)::Bool)
             end
         end
     end

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -640,12 +640,13 @@ supertypes:
 ```julia-repl
 julia> eltype_wrong(Union{Vector{Int}, Matrix{Int}})
 ERROR: MethodError: no method matching supertype(::Type{VecOrMat{Int64}})
+The function `supertype` exists, but no method is defined for this combination of argument types.
 
 Closest candidates are:
   supertype(::UnionAll)
-   @ Base operators.jl:44
+   @ Base operators.jl:87
   supertype(::DataType)
-   @ Base operators.jl:43
+   @ Base operators.jl:86
 ```
 
 ### Building a similar type with a different type parameter

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1471,7 +1471,7 @@ is raised:
 
 ```jldoctest; filter = r"Closest candidates.*"s
 julia> supertype(Union{Float64,Int64})
-ERROR: MethodError: no method matching supertype(::Core.TypeEgal{Union{Float64, Int64}})
+ERROR: MethodError: no method matching supertype(::Type{Union{Float64, Int64}})
 The function `supertype` exists, but no method is defined for this combination of argument types.
 
 Closest candidates are:


### PR DESCRIPTION
Since JuliaLang/julia#62001 introduced the egality kind, `Core.Typeof` of a closed type-valued argument is `Core.TypeEgal{X}`, and its canonical spelling leaks into every rendered call: MethodError headers now read `no method matching sqrt(::Core.TypeEgal{Int64})`, and the same appears in convert errors, ambiguity errors, stack-trace frames, and `MethodInstance` display — while method candidates and definitions continue to print the familiar `Type{X}` spelling.

This PR settles the display along a prescriptive/descriptive line:

- **Call display prints `::Type{X}`.** A printed call signature is what users copy into a method definition, and the method they should write is the idiomatic `zero(::Type{Int64})` (which accepts the `TypeEgal` argument), not a method on the internal kind. The mapping lives in `show_tuple_as_call` (covering MethodError/ambiguity headers, backtrace frames, and `MethodInstance` display, since `specTypes` genuinely carry `TypeEgal`) and `show_convert_error`, mirroring the identification `descend_params` already makes when highlighting candidate mismatches (JuliaLang/julia#61651). Reflection (`typesof`) is untouched.
- **Type display compact-prints the kind as `Core.Typeof(X)`.** Where the kind legitimately appears as a type (repr, container element types, methods defined on the kind, compiler output), `Core.TypeEgal{X}` gives no hint how to obtain such a type. `Core.Typeof(X)` round-trips exactly (`Core.Typeof(X) === Core.TypeEgal{X}` for closed `X`), analogous to the `typeof(sin)` spelling of function singleton types. The REPL shows `Core.Typeof(Int64) (alias for Core.TypeEgal{Int64})`, mirroring the existing `Type{Int64} (alias for TypeEq{Int64})`.
- **Candidate lists paint satisfiable trailing varargs gray.** The zero-arg-satisfiable vararg branch (from JuliaLang/julia#53165) predates the gray-matched convention of JuliaLang/julia#61651 and was left printing in the default color, e.g. `Any...` in `zero(::Type{Union{}}, Any...)`.

Known seam: a method explicitly defined on the kind shows `h(::Core.Typeof(Int64))` in candidates while a failing call's header prints the call-position `::Type{Int8}` spelling; this corner faces kinds-aware users and seems acceptable.

The `errorshow`, `ambiguous`, and `show` test suites pass, and the manual's doctests are updated (`methods.md`'s stale `julia-repl` block modernized alongside).

This pull request was written with the assistance of generative AI (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)